### PR TITLE
Add more prefs and switch when update message

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ hipchat-notifications
 
 A simple Pidgin plugin for personalized HipChat room notifications.
 
-All it does is look for messages that contain '@all' or '@\<your alias\>' and,
-when it finds one:
-  - colors the message
+All it does is look for messages that contain '@all', '@here' or
+'@\<your alias\>' and, when it finds one:
+  - colors the message (only if you are available for '@here')
   - updates the conversation title to show the number of unread messages
   - plays a sound to get your attention.
 

--- a/hipchat-notifications.pl
+++ b/hipchat-notifications.pl
@@ -207,7 +207,7 @@ sub receiving_chat_msg_cb {
     my $count = 0;
 
     # Check if this is a HipChat account
-    if ($account->get_username() =~ m|chat.hipchat.com/xmpp$|) {
+    if ($account->get_username() =~ m|(?<=[\.@])hipchat\..*/xmpp$|) {
 
 	# Check if the message was sent to all
 	$all = "\@all";


### PR DESCRIPTION
This adds some background color highlighting similar to how the native client does it, but only highlighting the "@<identifier>" part instead of colouring the entire message.

Also includes support for the "@here" identifier, but only notifies if your status is based on available.
